### PR TITLE
Count of null on PHP 7.2

### DIFF
--- a/src/Fixer/PhpBasic/Comment/PhpDocOnPropertiesFixer.php
+++ b/src/Fixer/PhpBasic/Comment/PhpDocOnPropertiesFixer.php
@@ -64,7 +64,7 @@ final class PhpDocOnPropertiesFixer extends AbstractFixer implements Whitespaces
 
     public function applyFix(\SplFileInfo $file, Tokens $tokens)
     {
-        $constructFunction = null;
+        $constructFunction = [];
         // Collecting __construct function info
         foreach ($tokens as $key => $token) {
             $functionTokenIndex = $tokens->getPrevNonWhitespace($key);
@@ -170,7 +170,10 @@ final class PhpDocOnPropertiesFixer extends AbstractFixer implements Whitespaces
     private function isPropertyDefinedInArguments($property, $constructFunction)
     {
         return
-            count($constructFunction['ConstructArguments']) > 0
+            (
+                isset($constructFunction['ConstructArguments'])
+                && count($constructFunction['ConstructArguments']) > 0
+            )
             && isset($property['Variable'])
             && in_array($property['Variable'], $constructFunction['ConstructArguments'], true)
         ;

--- a/src/Fixer/PhpBasic/Feature/TypeHintingFixer.php
+++ b/src/Fixer/PhpBasic/Feature/TypeHintingFixer.php
@@ -239,7 +239,7 @@ final class TypeHintingFixer extends AbstractFixer
      * @param Tokens $tokens
      * @param int $startIndex
      * @param int $endIndex
-     * @return array|null
+     * @return array
      */
     private function getConstructArgumentClassesAndAssignedProperties(Tokens $tokens, $startIndex, $endIndex)
     {
@@ -257,7 +257,7 @@ final class TypeHintingFixer extends AbstractFixer
 
         $curlyBraceStartIndex = $tokens->getNextMeaningfulToken($endIndex);
         if (!$tokens[$curlyBraceStartIndex]->equals('{') || count($constructClassProperties) === 0) {
-            return null;
+            return [];
         }
 
         $curlyBraceEndIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $curlyBraceStartIndex);

--- a/tests/Fixer/PhpBasic/Comment/PhpDocOnPropertiesFixerTest.php
+++ b/tests/Fixer/PhpBasic/Comment/PhpDocOnPropertiesFixerTest.php
@@ -23,6 +23,16 @@ final class PhpDocOnPropertiesFixerTest extends AbstractFixerTestCase
         return [
             [
                 '<?php
+class ClassWithPropertyButWithoutConstructor
+{
+    /**
+     * @var string
+     */
+    private $foo;
+}'
+            ],
+            [
+                '<?php
 class SomeClass
 {
     private $someProp;

--- a/tests/Fixer/PhpBasic/Feature/TypeHintingFixerTest.php
+++ b/tests/Fixer/PhpBasic/Feature/TypeHintingFixerTest.php
@@ -23,6 +23,15 @@ final class TypeHintingFixerTest extends AbstractFixerTestCase
         return [
             [
                 '<?php
+                class ClassWithConstructorWithoutParameters
+                {
+                    public function __construct()
+                    {
+                    }
+                }',
+            ],
+            [
+                '<?php
                 namespace Paysera\PhpCsFixerConfig\Tests\Fixer\PhpBasic\Feature;
                 use Paysera\PhpCsFixerConfig\Tests\Fixer\PhpBasic\Feature\Fixtures\SecurityContext;
                 


### PR DESCRIPTION
In some situations the code may try to do `count(null)` which [emits an `E_WARNING` since PHP 7.2.x](http://php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types). This causes the fixer to skip the problematic files with a similar error:
```
$ php-cs-fixer fix src/ --dry-run --diff -vvv
...
Files that were not fixed due to errors reported during fixing:
   1) src/Problematic.php


        [ErrorException]
        count(): Parameter must be an array or an object that implements Countable
...
```