### PR TITLE
Some functions without substitutions in PHP Date/Time classes were removed from DateTimeFixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Semantic Versioning is maintained only for the following:
 The fixers themselves can change their behavior on any update.
 New fixers could be added with minor releases, this would require changes in configuration if migration mode is used.
 
+## 2.2.3
+
+### Removed
+
+- Some functions without substitutions in PHP Date/Time classes were removed from DateTimeFixer
+
 ## 2.2.2
 
 ### Added

--- a/src/Fixer/PhpBasic/Feature/DateTimeFixer.php
+++ b/src/Fixer/PhpBasic/Feature/DateTimeFixer.php
@@ -20,13 +20,10 @@ final class DateTimeFixer extends AbstractFixer
     {
         parent::__construct();
         $this->dateFunctions = [
-            'checkdate',
             'date_add',
             'date_create_from_format',
             'date_create',
             'date_date_set',
-            'date_default_timezone_get',
-            'date_default_timezone_set',
             'date_diff',
             'date_format',
             'date_get_last_errors',
@@ -38,9 +35,6 @@ final class DateTimeFixer extends AbstractFixer
             'date_parse_from_format',
             'date_parse',
             'date_sub',
-            'date_sun_info',
-            'date_sunrise',
-            'date_sunset',
             'date_time_set',
             'date_timestamp_get',
             'date_timestamp_set',
@@ -54,7 +48,6 @@ final class DateTimeFixer extends AbstractFixer
             'gmstrftime',
             'idate',
             'localtime',
-            'microtime',
             'mktime',
             'strftime',
             'strptime',
@@ -63,12 +56,11 @@ final class DateTimeFixer extends AbstractFixer
             'timezone_abbreviations_list',
             'timezone_identifiers_list',
             'timezone_location_get',
-            'timezone_name_from_ abbr',
+            'timezone_name_from_abbr',
             'timezone_name_get',
             'timezone_offset_get',
             'timezone_open',
             'timezone_transitions_get',
-            'timezone_version_get',
         ];
     }
 

--- a/tests/Fixer/PhpBasic/Feature/DateTimeFixerTest.php
+++ b/tests/Fixer/PhpBasic/Feature/DateTimeFixerTest.php
@@ -27,10 +27,6 @@ final class DateTimeFixerTest extends AbstractPayseraFixerTestCase
                 '<?php $otherDate = date("l jS \of F Y h:i:s A");',
             ],
             [
-                '<?php date_default_timezone_set("UTC"); // TODO: "date_default_timezone_set" - PhpBasic convention 3.19: Use \\DateTime object instead',
-                '<?php date_default_timezone_set("UTC");',
-            ],
-            [
                 '<?php $someDate = date("l"); // TODO: "date" - PhpBasic convention 3.19: Use \\DateTime object instead',
                 '<?php $someDate = date("l");',
             ],


### PR DESCRIPTION
Some functions without substitutions in PHP Date/Time classes were removed from DateTimeFixer