### PR TITLE
Fix import alias ("AS" keyword) recognition in NamespacesAndUseStatementsFixer fixer

### DIFF
--- a/src/Fixer/PhpBasic/CodeStyle/NamespacesAndUseStatementsFixer.php
+++ b/src/Fixer/PhpBasic/CodeStyle/NamespacesAndUseStatementsFixer.php
@@ -275,6 +275,7 @@ final class NamespacesAndUseStatementsFixer extends AbstractFixer
         while (
             $token->isGivenKind(T_USE)
             || $token->isGivenKind(T_STRING)
+            || $token->isGivenKind(T_AS)
             || $token->getContent() === '\\'
             || $token->isWhitespace()
             || $token->getContent() === ';'

--- a/tests/Fixer/PhpBasic/CodeStyle/NamespacesAndUseStatementsFixerTest.php
+++ b/tests/Fixer/PhpBasic/CodeStyle/NamespacesAndUseStatementsFixerTest.php
@@ -881,6 +881,31 @@ function something(\App\Entity\Payment $a)
 {
 }'
             ],
+            [
+                '<?php
+namespace App;
+
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use DateTime;
+
+class Kernel extends BaseKernel
+{
+    public function something(DateTime $dateTime)
+    {
+    }
+}',
+                '<?php
+namespace App;
+
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+
+class Kernel extends BaseKernel
+{
+    public function something(\DateTime $dateTime)
+    {
+    }
+}'
+            ],
         ];
     }
 


### PR DESCRIPTION
Namespaces specified in code were replaced with import incorrectly when some aliased import was in code.

It happened because `...as...` keyword wasn't recognized.