### PR TITLE
CORE-2120: paysera/lib-php-cs-fixer-config: Parser class refactoring, other issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can look at `.travis.yml` file in this repository for integration with travi
 
 Run in project directory by command: `{your-bin-dir}/php-cs-fixer fix /path/to/code --verbose --dry-run --diff`
 
-Use `--config=.php-cs-fixer.php` flag for custom configuration.
+Use `--config=php-cs-fixer.php` flag for custom configuration.
 
 If `/path/to/code` is not defined `php-cs-fixer` will run files from default `src` directory excluding `Test` folders.
 

--- a/src/Fixer/PhpBasic/CodeStyle/SplittingInSeveralLinesFixer.php
+++ b/src/Fixer/PhpBasic/CodeStyle/SplittingInSeveralLinesFixer.php
@@ -330,9 +330,9 @@ PHP,
     private function hasExtraLinesWithCorrectEnding(string $current, string $replacement): bool
     {
         return (
-            str_starts_with($replacement, "\n")
-            && str_starts_with($current, "\n")
-            && str_ends_with($current, $replacement)
+            substr($replacement, 0, 1) === "\n"
+            && substr($current, 0, 1) === "\n"
+            && substr($current, -strlen($replacement)) === $replacement
         );
     }
 }


### PR DESCRIPTION
CORE-2120

The dependency on AbstractFixer was removed because it is internal, and some refactoring was done because of this.
The situation when there was a wrong indent in closures was fixed.
Wrong config file name in README.md